### PR TITLE
fix an issue where conf object.regexp returns undefined

### DIFF
--- a/src/angular-combine-decorator.js
+++ b/src/angular-combine-decorator.js
@@ -34,7 +34,7 @@ angular.module('angularCombine').config(function ($provide) {
 		$delegate.get = function (url) {
 			for (idx in angularCombineConfig) {
 				conf = angularCombineConfig[idx];
-				if (conf.regexp.test(url)) {
+				if (conf.regexp && conf.regexp.test(url)) {
 					return conf.load(url);
 				}
 			}


### PR DESCRIPTION
hi @astik, `conf.regexp` returns undefined for some reasons, especially when running inside a sandbox salesforce environment. Strangely, it works fine with any other environment. so I'm just wondering if others might have run into the same issue. and perhaps it would be beneficial to put a guard clause against that condition.
